### PR TITLE
GTest changes for common setup and lint fixes

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -28,6 +28,7 @@ BraceWrapping:
   AfterObjCDeclaration: false
   AfterStruct:     false
   AfterUnion:      false
+  AfterExternBlock: false
   BeforeCatch:     false
   BeforeElse:      false
   IndentBraces:    false
@@ -57,7 +58,10 @@ ForEachMacros:
   - foreach
   - Q_FOREACH
   - BOOST_FOREACH
+IncludeBlocks:   Regroup
 IncludeCategories: 
+  - Regex:           '^<ext/.*\.h>'
+    Priority:        2
   - Regex:           '^<.*\.h>'
     Priority:        1
   - Regex:           '^<.*'
@@ -66,6 +70,7 @@ IncludeCategories:
     Priority:        3
 IncludeIsMainRegex: '([-_](test|unittest))?$'
 IndentCaseLabels: true
+IndentPPDirectives: None
 IndentWidth:     4
 IndentWrappedFunctionNames: false
 JavaScriptQuotes: Leave
@@ -86,6 +91,10 @@ PenaltyBreakString: 1000
 PenaltyExcessCharacter: 1000000
 PenaltyReturnTypeOnItsOwnLine: 200
 PointerAlignment: Left
+RawStringFormats:
+  - Delimiter:       pb
+    Language:        TextProto
+    BasedOnStyle:    google
 ReflowComments:  true
 SortIncludes:    true
 SortUsingDeclarations: true
@@ -101,7 +110,7 @@ SpacesInCStyleCastParentheses: false
 SpacesInParentheses: false
 SpacesInSquareBrackets: false
 Standard:        Auto
-TabWidth:        8
+TabWidth:        4
 UseTab:          Never
 ...
 

--- a/test/gtest/include/TapIf.h
+++ b/test/gtest/include/TapIf.h
@@ -19,44 +19,54 @@
 // as noted in the Third-Party source code file.
 //
 
-#ifndef __TapIf__
-#define __TapIf__
+#ifndef TEST_GTEST_INCLUDE_TAPIF_H_
+#define TEST_GTEST_INCLUDE_TAPIF_H_
 
-#include "Utils.h"
+#include <linux/if_tun.h>
+#include <net/if.h>
+#include <unistd.h>
+
+#include <cstring>
+#include <iostream>
+#include <string>
 
 class TapIf
 {
-public:
-    TapIf (const std::string &ifNameStr) {
-	    strncpy(_ifName, ifNameStr.c_str(), IFNAMSIZ);
-		_ifName[IFNAMSIZ - 1] = '\0';
-	}
+ public:
+    explicit TapIf(const std::string &ifNameStr)
+    {
+        strncpy(_ifName, ifNameStr.c_str(), IFNAMSIZ);
+        _ifName[IFNAMSIZ - 1] = '\0';
+    }
 
-    ~TapIf () {
+    ~TapIf()
+    {
         if (_tapFd) {
             close(_tapFd);
         }
     }
 
-	int init(void) {
-		int tapFd;
-		int flags = IFF_TAP;
+    int init(void)
+    {
+        int tapFd;
+        int flags = IFF_TAP;
 
-		/* initialize tun/tap interface */
-		if ( (tapFd = tapAlloc(_ifName, flags | IFF_NO_PI)) < 0 ) {
-			std::cout << "Error connecting to tap interface " << _ifName << std::endl;
-			return -1;
-		}
-		_tapFd = tapFd;
-		return _tapFd;
-	}
+        /* initialize tun/tap interface */
+        if ((tapFd = tapAlloc(_ifName, flags | IFF_NO_PI)) < 0) {
+            std::cout << "Error connecting to tap interface " << _ifName
+                      << std::endl;
+            return -1;
+        }
+        _tapFd = tapFd;
+        return _tapFd;
+    }
 
     int tapAlloc(char *dev, int flags);
-	int ifRead(void);
+    int ifRead(void);
 
-private:
+ private:
     char _ifName[IFNAMSIZ];
-	int  _tapFd{0};
+    int  _tapFd{0};
 };
 
-#endif // __TapIf__
+#endif  // TEST_GTEST_INCLUDE_TAPIF_H_

--- a/test/gtest/include/TestPacket.h
+++ b/test/gtest/include/TestPacket.h
@@ -19,22 +19,25 @@
 // as noted in the Third-Party source code file.
 //
 
-#ifndef __TestPacket__
-#define __TestPacket__
+#ifndef TEST_GTEST_INCLUDE_TESTPACKET_H_
+#define TEST_GTEST_INCLUDE_TESTPACKET_H_
 
 #include <netinet/ether.h>
-#include <vector>
-#include <map>
-#include <boost/algorithm/string.hpp>
-#include "Utils.h"
-#include "P4InfoUtils.h"
 
-#define MAC_ADDR_LEN            6
-#define ETHER_PAYLOAD_BUF_SIZE	5000
+#include <boost/algorithm/string.hpp>
+#include <map>
+#include <string>
+#include <vector>
+
+#include "P4InfoUtils.h"
+#include "Utils.h"
+
+#define MAC_ADDR_LEN 6
+#define ETHER_PAYLOAD_BUF_SIZE 5000
 
 class TestPacket
 {
-public:
+ public:
     int setSrcMac(const std::string &mac)
     {
         std::vector<std::string> mac_sub_strings;
@@ -76,57 +79,57 @@ public:
 
     int getEtherPacket(char *pktData, int pktDataBuffLen)
     {
-#define ETH_HEADER_LEN    14
+#define ETH_HEADER_LEN 14
         int i = 0;
 
         if (pktDataBuffLen < ETH_HEADER_LEN) {
-		    return -1;
-		}
+            return -1;
+        }
 
-		for (i = 0; i < MAC_ADDR_LEN; i++) {
+        for (i = 0; i < MAC_ADDR_LEN; i++) {
             pktData[i] = _dstMac[i];
         }
 
-		for (i = 0; i < MAC_ADDR_LEN; i++) {
+        for (i = 0; i < MAC_ADDR_LEN; i++) {
             pktData[MAC_ADDR_LEN + i] = _srcMac[i];
         }
 
         pktData[ETH_HEADER_LEN - 2] = ((_etherType >> 8) & 0xFF);
-        pktData[ETH_HEADER_LEN - 1] = ((_etherType) & 0xFF);
+        pktData[ETH_HEADER_LEN - 1] = ((_etherType)&0xFF);
 
-		int pktDataLen = convertHexPktStrToPkt(_etherPayload, 
-				  							   &pktData[ETH_HEADER_LEN], 
-											   pktDataBuffLen - ETH_HEADER_LEN);
-	    return (ETH_HEADER_LEN + pktDataLen);
-	}
+        int pktDataLen =
+            convertHexPktStrToPkt(_etherPayload, &pktData[ETH_HEADER_LEN],
+                                  pktDataBuffLen - ETH_HEADER_LEN);
+        return (ETH_HEADER_LEN + pktDataLen);
+    }
 
-private:
-	int  _srcMac[MAC_ADDR_LEN];
-	int  _dstMac[MAC_ADDR_LEN];
+ private:
+    int _srcMac[MAC_ADDR_LEN];
+    int _dstMac[MAC_ADDR_LEN];
 
-	// ETH_P_IP =  0x0800
-	int  _etherType;
-	char _etherPayload[ETHER_PAYLOAD_BUF_SIZE];
+    // ETH_P_IP =  0x0800
+    int  _etherType;
+    char _etherPayload[ETHER_PAYLOAD_BUF_SIZE];
 };
 
 class TestPacketLibrary
 {
-public:
-    //  
+ public:
+    //
     // Test Packet Id.
-    //  
-	typedef enum {
+    //
+    enum TestPacketId {
         TestPacketIdInvalid = 0,
-		TEST_PKT_ID_IPV4_ECHO_REQ_TO_TAP1,
-		TEST_PKT_ID_IPV4_ECHO_REQ_TO_TAP2,
-		TEST_PKT_ID_IPV4_ROUTER_ICMP_ECHO_TO_TAP3,
-		VMXZT_TEST_PKT_ID_IPV4_ROUTER_ICMP_ECHO_TO_TAP3,
-        TEST_PKT_ID_PUNT_ICMP_ECHO, 
-		TEST_PKT_ID_IPV4_VLAN,
-		TEST_PKT_ID_MPLS_L2VLAN,
-		TEST_PKT_ID_IPV4_ROUTER_ICMP_ECHO_TO_TAP7,
+        TEST_PKT_ID_IPV4_ECHO_REQ_TO_TAP1,
+        TEST_PKT_ID_IPV4_ECHO_REQ_TO_TAP2,
+        TEST_PKT_ID_IPV4_ROUTER_ICMP_ECHO_TO_TAP3,
+        VMXZT_TEST_PKT_ID_IPV4_ROUTER_ICMP_ECHO_TO_TAP3,
+        TEST_PKT_ID_PUNT_ICMP_ECHO,
+        TEST_PKT_ID_IPV4_VLAN,
+        TEST_PKT_ID_MPLS_L2VLAN,
+        TEST_PKT_ID_IPV4_ROUTER_ICMP_ECHO_TO_TAP7,
         TestPacketIdMax,
-	} TestPacketId;
+    };
 
     TestPacketLibrary() { buildTestPacketLibrary(); }
 
@@ -140,15 +143,15 @@ public:
 
     void buildTestPacketLibrary(void);
 
-private:
+ private:
     using TestPacketLibraryMap = std::map<TestPacketId, TestPacket>;
 
     TestPacketLibraryMap _testPacketLibrary;
 };
 
 //
-// Test Packet Library 
+// Test Packet Library
 //
 extern TestPacketLibrary testPacketLibrary;
 
-#endif // __TestPacket__
+#endif  // TEST_GTEST_INCLUDE_TESTPACKET_H_

--- a/test/gtest/include/TestUtils.h
+++ b/test/gtest/include/TestUtils.h
@@ -18,13 +18,17 @@
 // components is subject to the terms and conditions of the respective license
 // as noted in the Third-Party source code file.
 //
+#ifndef TEST_GTEST_INCLUDE_TESTUTILS_H_
+#define TEST_GTEST_INCLUDE_TESTUTILS_H_
 
-#ifndef __TestUtils__
-#define __TestUtils__
-
-#include <net/if.h>
 #include <linux/if_tun.h>
+#include <net/if.h>
+
 #include <chrono>
+#include <string>
+#include <vector>
+
+#include "TestPacket.h"
 
 extern std::string gTestTimeStr;
 extern std::string gtestOutputDirName;
@@ -32,15 +36,15 @@ extern std::string gtestExpectedDirName;
 extern std::string tsharkBinary;
 
 std::string getTimeStr();
-void sleep_thread_log(std::chrono::milliseconds nms);
-void tVerifyPackets(const std::vector<std::string> &interfaces);
+void        sleep_thread_log(std::chrono::milliseconds nms);
+void        tVerifyPackets(const std::vector<std::string> &interfaces);
 void start_pktcap(const std::vector<std::string> &intfs, unsigned int num_pkts,
                   unsigned int timeout_sec, std::vector<pid_t> &pids);
 bool stop_pktcap(const std::vector<std::string> &intfs,
-                 const std::vector<pid_t> &pids);
+                 const std::vector<pid_t> &      pids);
 
-extern int SendRawEth(const std::string &ifNameStr,
+extern int SendRawEth(const std::string &             ifNameStr,
                       TestPacketLibrary::TestPacketId tcPktNum);
-void send_arp_req(const std::string &ifname, const char *target_ip_addr);
+void       send_arp_req(const std::string &ifname, const char *target_ip_addr);
 
-#endif // __TestUtils__
+#endif  // TEST_GTEST_INCLUDE_TESTUTILS_H_

--- a/test/gtest/include/TestUtils.h
+++ b/test/gtest/include/TestUtils.h
@@ -18,6 +18,7 @@
 // components is subject to the terms and conditions of the respective license
 // as noted in the Third-Party source code file.
 //
+
 #ifndef TEST_GTEST_INCLUDE_TESTUTILS_H_
 #define TEST_GTEST_INCLUDE_TESTUTILS_H_
 
@@ -30,20 +31,24 @@
 
 #include "TestPacket.h"
 
-extern std::string gTestTimeStr;
-extern std::string gtestOutputDirName;
-extern std::string gtestExpectedDirName;
-extern std::string tsharkBinary;
+bool createGtestResultDir();
+bool createTestOutDir();
+void sleep_thread_log(std::chrono::milliseconds nms);
 
-std::string getTimeStr();
-void        sleep_thread_log(std::chrono::milliseconds nms);
-void        tVerifyPackets(const std::vector<std::string> &interfaces);
-void start_pktcap(const std::vector<std::string> &intfs, unsigned int num_pkts,
-                  unsigned int timeout_sec, std::vector<pid_t> &pids);
+void tVerifyPackets(const std::string &             tOutputDir,
+                    const std::string &             tExpectedDir,
+                    const std::vector<std::string> &interfaces);
+
+std::vector<pid_t> start_pktcap(const std::string &             tOutputDir,
+                                const std::vector<std::string> &intfs,
+                                unsigned int                    num_pkts,
+                                unsigned int                    timeout_sec);
+
 bool stop_pktcap(const std::vector<std::string> &intfs,
                  const std::vector<pid_t> &      pids);
 
-int  SendRawEth(const char *ifName, TestPacketLibrary::TestPacketId tcPktNum);
-void send_arp_req(const char *ifname, const char *target_ip_addr);
+extern int SendRawEth(const char *                    ifNameStr,
+                      TestPacketLibrary::TestPacketId tcPktNum);
+void       send_arp_req(const char *ifname, const char *target_ip_addr);
 
 #endif  // TEST_GTEST_INCLUDE_TESTUTILS_H_

--- a/test/gtest/include/TestUtils.h
+++ b/test/gtest/include/TestUtils.h
@@ -43,8 +43,7 @@ void start_pktcap(const std::vector<std::string> &intfs, unsigned int num_pkts,
 bool stop_pktcap(const std::vector<std::string> &intfs,
                  const std::vector<pid_t> &      pids);
 
-extern int SendRawEth(const std::string &             ifNameStr,
-                      TestPacketLibrary::TestPacketId tcPktNum);
-void       send_arp_req(const std::string &ifname, const char *target_ip_addr);
+int  SendRawEth(const char *ifName, TestPacketLibrary::TestPacketId tcPktNum);
+void send_arp_req(const char *ifname, const char *target_ip_addr);
 
 #endif  // TEST_GTEST_INCLUDE_TESTUTILS_H_

--- a/test/gtest/src/GTest.cpp
+++ b/test/gtest/src/GTest.cpp
@@ -112,10 +112,6 @@ using namespace std::chrono_literals;
 // root@de5cf35cd169:~#
 //
 
-// const std::string afiServerAddr   = "128.0.0.16:50051"; // grpc/tcp
-const std::string afiServerAddr  = "172.18.0.1:65051";  // grpc/tcp
-const std::string afiHospathAddr = "128.0.0.16:9002";   // udp
-
 //
 //              |
 //   ,-----.    |
@@ -126,59 +122,31 @@ const std::string afiHospathAddr = "128.0.0.16:9002";   // udp
 //              |
 //
 
-const std::string GE_0_0_0_MAC_STR = "fe:26:0a:2e:aa:f0";
-const std::string GE_0_0_1_MAC_STR = "fe:26:0a:2e:aa:f1";
-const std::string GE_0_0_2_MAC_STR = "fe:26:0a:2e:aa:f2";
-const std::string GE_0_0_3_MAC_STR = "fe:26:0a:2e:aa:f3";
-const std::string GE_0_0_4_MAC_STR = "fe:26:0a:2e:aa:f4";
-const std::string GE_0_0_5_MAC_STR = "fe:26:0a:2e:aa:f5";
-const std::string GE_0_0_6_MAC_STR = "fe:26:0a:2e:aa:f6";
-const std::string GE_0_0_7_MAC_STR = "fe:26:0a:2e:aa:f7";
+struct intf {
+    const char *if_name;
+    const char *mac_str;
+    const char *ip_addr;
+};
 
-const std::string GE_0_0_0_VMX_IF_NAME = "ge-0.0.0-vmx1";
-const std::string GE_0_0_1_VMX_IF_NAME = "ge-0.0.1-vmx1";
-const std::string GE_0_0_2_VMX_IF_NAME = "ge-0.0.2-vmx1";
-const std::string GE_0_0_3_VMX_IF_NAME = "ge-0.0.3-vmx1";
-const std::string GE_0_0_4_VMX_IF_NAME = "ge-0.0.4-vmx1";
-const std::string GE_0_0_5_VMX_IF_NAME = "ge-0.0.5-vmx1";
-const std::string GE_0_0_6_VMX_IF_NAME = "ge-0.0.6-vmx1";
-const std::string GE_0_0_7_VMX_IF_NAME = "ge-0.0.7-vmx1";
+static constexpr intf ge_intfs[] = {
+    {"ge-0.0.0-vmx1", "fe:26:0a:2e:aa:f0", "103.30.100.1"},
+    {"ge-0.0.1-vmx1", "fe:26:0a:2e:aa:f1", "103.30.110.1"},
+    {"ge-0.0.2-vmx1", "fe:26:0a:2e:aa:f2", "103.30.120.1"},
+    {"ge-0.0.3-vmx1", "fe:26:0a:2e:aa:f3", "103.30.130.1"},
+    {"ge-0.0.4-vmx1", "fe:26:0a:2e:aa:f4", "103.30.140.1"},
+    {"ge-0.0.5-vmx1", "fe:26:0a:2e:aa:f5", "103.30.150.1"},
+    {"ge-0.0.6-vmx1", "fe:26:0a:2e:aa:f6", "103.30.160.1"},
+    {"ge-0.0.7-vmx1", "fe:26:0a:2e:aa:f7", "103.30.170.1"}};
 
-const std::string GE_0_0_0_IP_ADDR_STR = "103.30.100.1";
-const std::string GE_0_0_1_IP_ADDR_STR = "103.30.110.1";
-const std::string GE_0_0_2_IP_ADDR_STR = "103.30.120.1";
-const std::string GE_0_0_3_IP_ADDR_STR = "103.30.130.1";
-const std::string GE_0_0_4_IP_ADDR_STR = "103.30.140.1";
-const std::string GE_0_0_5_IP_ADDR_STR = "103.30.150.1";
-const std::string GE_0_0_6_IP_ADDR_STR = "103.30.160.1";
-const std::string GE_0_0_7_IP_ADDR_STR = "103.30.170.1";
-
-const std::string VMX_LINK0_NAME_STR = "vmx_link10";
-const std::string VMX_LINK1_NAME_STR = "vmx_link11";
-const std::string VMX_LINK2_NAME_STR = "vmx_link12";
-const std::string VMX_LINK3_NAME_STR = "vmx_link13";
-const std::string VMX_LINK4_NAME_STR = "vmx_link14";
-const std::string VMX_LINK5_NAME_STR = "vmx_link15";
-const std::string VMX_LINK6_NAME_STR = "vmx_link16";
-const std::string VMX_LINK7_NAME_STR = "vmx_link17";
-
-const std::string VMX_LINK0_MAC_STR = "32:26:0a:2e:bb:f0";
-const std::string VMX_LINK1_MAC_STR = "32:26:0a:2e:bb:f1";
-const std::string VMX_LINK2_MAC_STR = "32:26:0a:2e:bb:f2";
-const std::string VMX_LINK3_MAC_STR = "32:26:0a:2e:bb:f3";
-const std::string VMX_LINK4_MAC_STR = "32:26:0a:2e:bb:f4";
-const std::string VMX_LINK5_MAC_STR = "32:26:0a:2e:bb:f5";
-const std::string VMX_LINK6_MAC_STR = "32:26:0a:2e:bb:f6";
-const std::string VMX_LINK7_MAC_STR = "32:26:0a:2e:bb:f7";
-
-const std::string VMX_LINK0_IP_ADDR_STR = "103.30.100.2";
-const std::string VMX_LINK1_IP_ADDR_STR = "103.30.110.2";
-const std::string VMX_LINK2_IP_ADDR_STR = "103.30.120.2";
-const std::string VMX_LINK3_IP_ADDR_STR = "103.30.130.2";
-const std::string VMX_LINK4_IP_ADDR_STR = "103.30.140.2";
-const std::string VMX_LINK5_IP_ADDR_STR = "103.30.150.2";
-const std::string VMX_LINK6_IP_ADDR_STR = "103.30.160.2";
-const std::string VMX_LINK7_IP_ADDR_STR = "103.30.170.2";
+static constexpr intf vmx_links[] = {
+    {"vmx_link10", "32:26:0a:2e:bb:f0", "103.30.100.2"},
+    {"vmx_link11", "32:26:0a:2e:bb:f1", "103.30.110.2"},
+    {"vmx_link12", "32:26:0a:2e:bb:f2", "103.30.120.2"},
+    {"vmx_link13", "32:26:0a:2e:bb:f3", "103.30.130.2"},
+    {"vmx_link14", "32:26:0a:2e:bb:f4", "103.30.140.2"},
+    {"vmx_link15", "32:26:0a:2e:bb:f5", "103.30.150.2"},
+    {"vmx_link16", "32:26:0a:2e:bb:f6", "103.30.160.2"},
+    {"vmx_link17", "32:26:0a:2e:bb:f7", "103.30.170.2"}};
 
 /*
  * IPv4 Router
@@ -220,7 +188,7 @@ TEST_F(P4, injectL2Pkt)
     constexpr int      pcap_timeout_sec = 10;
 
     // Start listening for pkts.
-    const std::vector<std::string> capture_ifs{GE_0_0_2_VMX_IF_NAME};
+    const std::vector<std::string> capture_ifs{ge_intfs[2].if_name};
     std::vector<pid_t>             pcap_pids;
     ASSERT_NO_FATAL_FAILURE(
         start_pktcap(capture_ifs, num_pkts, pcap_timeout_sec, pcap_pids));
@@ -269,7 +237,7 @@ TEST_F(P4, puntL2Pkt)
 
     constexpr int                  num_pkts         = 1;
     constexpr int                  pcap_timeout_sec = 10;
-    const std::vector<std::string> capture_ifs{GE_0_0_2_VMX_IF_NAME};
+    const std::vector<std::string> capture_ifs{ge_intfs[2].if_name};
     std::vector<pid_t>             pcap_pids;
     ASSERT_NO_FATAL_FAILURE(
         start_pktcap(capture_ifs, num_pkts, pcap_timeout_sec, pcap_pids));
@@ -277,7 +245,7 @@ TEST_F(P4, puntL2Pkt)
 
     // Send RawEth pkt on vmx_link2
     int ret = SendRawEth(
-        VMX_LINK2_NAME_STR,
+        vmx_links[2].if_name,
         TestPacketLibrary::VMXZT_TEST_PKT_ID_IPV4_ROUTER_ICMP_ECHO_TO_TAP3);
     EXPECT_EQ(0, ret) << "Failed to send pkt to VMX_LINK2";
 
@@ -312,7 +280,7 @@ TEST_F(P4, hostPing)
 
     constexpr int                  num_pkts         = 2;
     constexpr int                  pcap_timeout_sec = 10;
-    const std::vector<std::string> capture_ifs{GE_0_0_2_VMX_IF_NAME};
+    const std::vector<std::string> capture_ifs{ge_intfs[2].if_name};
     std::vector<pid_t>             pcap_pids;
     ASSERT_NO_FATAL_FAILURE(
         start_pktcap(capture_ifs, num_pkts, pcap_timeout_sec, pcap_pids));
@@ -320,7 +288,7 @@ TEST_F(P4, hostPing)
 
     // Send ICMP Echo request.
     int ret = SendRawEth(
-        VMX_LINK2_NAME_STR,
+        vmx_links[2].if_name,
         TestPacketLibrary::VMXZT_TEST_PKT_ID_IPV4_ROUTER_ICMP_ECHO_TO_TAP3);
     EXPECT_EQ(0, ret) << "Failed to send pkt to VMX_LINK2";
 
@@ -344,7 +312,7 @@ TEST_F(P4, sendArpReq)
 
     constexpr int                  num_pkts = 2;  // ARP request and reply.
     constexpr int                  pcap_timeout_sec = 10;
-    const std::vector<std::string> capture_ifs{GE_0_0_2_VMX_IF_NAME};
+    const std::vector<std::string> capture_ifs{ge_intfs[2].if_name};
     std::vector<pid_t>             pcap_pids;
     ASSERT_NO_FATAL_FAILURE(
         start_pktcap(capture_ifs, num_pkts, pcap_timeout_sec, pcap_pids));
@@ -352,7 +320,7 @@ TEST_F(P4, sendArpReq)
 
     // Construct and send ARP request
     EXPECT_NO_FATAL_FAILURE(
-        send_arp_req(VMX_LINK2_NAME_STR, GE_0_0_2_IP_ADDR_STR.c_str()));
+        send_arp_req(vmx_links[2].if_name, ge_intfs[2].ip_addr));
 
     // Wait for pcap child processes
     ASSERT_TRUE(stop_pktcap(capture_ifs, pcap_pids))
@@ -376,8 +344,8 @@ TEST_F(P4, ipv4Router)
     const int pcap_timeout_sec = 10;
 
     // Start packet capture on ingress and egress interfaces.
-    const std::vector<std::string> capture_ifs{GE_0_0_2_VMX_IF_NAME,
-                                               GE_0_0_3_VMX_IF_NAME};
+    const std::vector<std::string> capture_ifs{ge_intfs[2].if_name,
+                                               ge_intfs[3].if_name};
     std::vector<pid_t>             pcap_pids;
     ASSERT_NO_FATAL_FAILURE(start_pktcap(capture_ifs, num_pkts_to_send,
                                          pcap_timeout_sec, pcap_pids));
@@ -386,7 +354,7 @@ TEST_F(P4, ipv4Router)
     // Send L2 packet.
     for (int i = 0; i < num_pkts_to_send; i++) {
         int ret = SendRawEth(
-            VMX_LINK2_NAME_STR,
+            vmx_links[2].if_name,
             TestPacketLibrary::VMXZT_TEST_PKT_ID_IPV4_ROUTER_ICMP_ECHO_TO_TAP3);
         EXPECT_EQ(0, ret);
         std::this_thread::sleep_for(1s);

--- a/test/gtest/src/Makefile
+++ b/test/gtest/src/Makefile
@@ -32,7 +32,7 @@ CXXFLAGS += \
 	-L$(GTEST_DIR)/make \
 	-L$(CONTROLLER_DIR)/obj \
 	-std=c++14 \
-	-Wall \
+	-Wall -Werror
 
 ifdef DEBUG_BUILD
 	CXXFLAGS += -g -O0

--- a/test/gtest/src/TestPacket.cpp
+++ b/test/gtest/src/TestPacket.cpp
@@ -26,8 +26,8 @@
 //
 TestPacketLibrary testPacketLibrary;
 
-
-void TestPacketLibrary::buildTestPacketLibrary(void)
+void
+TestPacketLibrary::buildTestPacketLibrary(void)
 {
     TestPacket *testPkt;
 
@@ -35,104 +35,104 @@ void TestPacketLibrary::buildTestPacketLibrary(void)
     // TEST_PKT_ID_IPV4_ECHO_REQ_TO_TAP1
     //
     // Mac tap1 32:26:0a:2e:cc:f1
-	// Src IP : 103.30.10.1
-	// Dst IP : 103.30.10.3
+    // Src IP : 103.30.10.1
+    // Dst IP : 103.30.10.3
     //
     testPkt = &_testPacketLibrary[TEST_PKT_ID_IPV4_ECHO_REQ_TO_TAP1];
 
-    //testPkt->setDstMac("32:26:0a:2e:cc:f1");
+    // testPkt->setDstMac("32:26:0a:2e:cc:f1");
     testPkt->setDstMac("33:22:0a:2e:ff:f1");
     testPkt->setSrcMac("32:26:0A:2E:aa:F1");
-    testPkt->setEtherType(ETH_P_IP); // 0x0800 
+    testPkt->setEtherType(ETH_P_IP);  // 0x0800
     testPkt->setEtherPayloadStr(
-		"4500 0054 dacc 4000 4001 7d9c"
-        "671e 0a01 671e 0a03" 
+        "4500 0054 dacc 4000 4001 7d9c"
+        "671e 0a01 671e 0a03"
         "0800 5cba 492b 3942 ee7c 5658 0000"
-		"0000 0a30 0b00 0000 0000 1011 1213 1415"
-		"1617 1819 1a1b 1c1d 1e1f 2021 2223 2425"
-		"2627 2829 2a2b 2c2d 2e2f 3031 3233 3435"
-		"3637");
+        "0000 0a30 0b00 0000 0000 1011 1213 1415"
+        "1617 1819 1a1b 1c1d 1e1f 2021 2223 2425"
+        "2627 2829 2a2b 2c2d 2e2f 3031 3233 3435"
+        "3637");
 
     //
     // TEST_PKT_ID_IPV4_ECHO_REQ_TO_TAP2
     //
-    // Mac tap2 7a:44:b9:85:3e:10 
-	// Src IP : 103.30.80.1
-	// Dst IP : 103.30.80.3
+    // Mac tap2 7a:44:b9:85:3e:10
+    // Src IP : 103.30.80.1
+    // Dst IP : 103.30.80.3
     testPkt = &_testPacketLibrary[TEST_PKT_ID_IPV4_ECHO_REQ_TO_TAP2];
 
     testPkt->setDstMac("7A:44:B9:85:3E:10");
     testPkt->setSrcMac("32:26:0A:2E:FF:F3");
-    testPkt->setEtherType(ETH_P_IP); // 0x0800 
+    testPkt->setEtherType(ETH_P_IP);  // 0x0800
     testPkt->setEtherPayloadStr(
-		"4500 0054 dacc 4000 4001 f19b"
-		"671e 5001 671e 5003 "
-		"0800 5cba 492b 3942 ee7c 5658 0000"
-		"0000 0a30 0b00 0000 0000 1011 1213 1415"
-		"1617 1819 1a1b 1c1d 1e1f 2021 2223 2425"
-		"2627 2829 2a2b 2c2d 2e2f 3031 3233 3435"
-		"3637");
+        "4500 0054 dacc 4000 4001 f19b"
+        "671e 5001 671e 5003 "
+        "0800 5cba 492b 3942 ee7c 5658 0000"
+        "0000 0a30 0b00 0000 0000 1011 1213 1415"
+        "1617 1819 1a1b 1c1d 1e1f 2021 2223 2425"
+        "2627 2829 2a2b 2c2d 2e2f 3031 3233 3435"
+        "3637");
 
     // tap2 mac     : 32:26:0a:2e:cc:f2
     // ge-0/0/2 mac : 32:26:0a:2e:aa:f2
     //
     // TEST_PKT_ID_IPV4_ROUTER_ICMP_ECHO_TO_TAP3
     //
-    // tap3 mac : 7a:44:b9:85:3e:10 
-	// 
-	// Src IP : 103.30.20.2
-	// Dst IP : 103.30.30.3
+    // tap3 mac : 7a:44:b9:85:3e:10
+    //
+    // Src IP : 103.30.20.2
+    // Dst IP : 103.30.30.3
     testPkt = &_testPacketLibrary[TEST_PKT_ID_IPV4_ROUTER_ICMP_ECHO_TO_TAP3];
 
     testPkt->setDstMac("32:26:0a:2e:aa:f2");
     testPkt->setSrcMac("32:26:0A:2E:BB:F2");
-    testPkt->setEtherType(ETH_P_IP); // 0x0800 
+    testPkt->setEtherType(ETH_P_IP);  // 0x0800
     testPkt->setEtherPayloadStr(
-		"4500 0054 dacc 4000 4001 5f9c"
-		"671e 1401 671e 1E03"
-		"0800 5cba 492b 3942 ee7c 5658 0000"
-		"0000 0a30 0b00 0000 0000 1011 1213 1415"
-		"1617 1819 1a1b 1c1d 1e1f 2021 2223 2425"
-		"2627 2829 2a2b 2c2d 2e2f 3031 3233 3435"
-		"3637");
+        "4500 0054 dacc 4000 4001 5f9c"
+        "671e 1401 671e 1E03"
+        "0800 5cba 492b 3942 ee7c 5658 0000"
+        "0000 0a30 0b00 0000 0000 1011 1213 1415"
+        "1617 1819 1a1b 1c1d 1e1f 2021 2223 2425"
+        "2627 2829 2a2b 2c2d 2e2f 3031 3233 3435"
+        "3637");
 
     // tap2 mac     : 32:26:0a:2e:cc:f2
     // xe-0/0/0:1   : 00:05:86:75:5c:01
     //
     // VMXZT_TEST_PKT_ID_IPV4_ROUTER_ICMP_ECHO_TO_TAP3
     //
-    // tap3 mac : 7a:44:b9:85:3e:10 
-	// 
-	// Src IP : 103.30.20.2
-	// Dst IP : 103.30.30.3
+    // tap3 mac : 7a:44:b9:85:3e:10
+    //
+    // Src IP : 103.30.20.2
+    // Dst IP : 103.30.30.3
     testPkt =
         &_testPacketLibrary[VMXZT_TEST_PKT_ID_IPV4_ROUTER_ICMP_ECHO_TO_TAP3];
 
     testPkt->setDstMac("2C:6B:F5:75:5c:01");
     testPkt->setSrcMac("32:26:0A:2E:BB:F2");
-    testPkt->setEtherType(ETH_P_IP); // 0x0800 
+    testPkt->setEtherType(ETH_P_IP);  // 0x0800
     testPkt->setEtherPayloadStr(
-		"4500 0054 dacc 4000 4001 5f9c"
-		"671e 1401 671e 1E03"
-		"0800 5cba 492b 3942 ee7c 5658 0000"
-		"0000 0a30 0b00 0000 0000 1011 1213 1415"
-		"1617 1819 1a1b 1c1d 1e1f 2021 2223 2425"
-		"2627 2829 2a2b 2c2d 2e2f 3031 3233 3435"
-		"3637");
+        "4500 0054 dacc 4000 4001 5f9c"
+        "671e 1401 671e 1E03"
+        "0800 5cba 492b 3942 ee7c 5658 0000"
+        "0000 0a30 0b00 0000 0000 1011 1213 1415"
+        "1617 1819 1a1b 1c1d 1e1f 2021 2223 2425"
+        "2627 2829 2a2b 2c2d 2e2f 3031 3233 3435"
+        "3637");
 
     //
     // TEST_PKT_ID_PUNT_ICMP_ECHO
     //
-	// Src IP : 103.30.00.2
-	// Dst IP : 103.30.00.1
+    // Src IP : 103.30.00.2
+    // Dst IP : 103.30.00.1
     testPkt = &_testPacketLibrary[TEST_PKT_ID_PUNT_ICMP_ECHO];
 
-    testPkt->setEtherType(ETH_P_IP); // 0x0800 
+    testPkt->setEtherType(ETH_P_IP);  // 0x0800
     testPkt->setDstMac("33:22:0A:2E:AA:F1");
     testPkt->setEtherPayloadStr(
         "4500 0054 a038 4000 4001 cc31"
-		"671e 0002 671e 0001 "
-		"0800 bf46 3271 0001 06f8 8558"
+        "671e 0002 671e 0001 "
+        "0800 bf46 3271 0001 06f8 8558"
         "0000 0000 bb23 0000 0000 0000 1011 1213"
         "1415 1617 1819 1a1b 1c1d 1e1f 2021 2223"
         "2425 2627 2829 2a2b 2c2d 2e2f 3031 3233"
@@ -143,7 +143,7 @@ void TestPacketLibrary::buildTestPacketLibrary(void)
     //
     testPkt = &_testPacketLibrary[TEST_PKT_ID_IPV4_VLAN];
 
-    testPkt->setEtherType(ETH_P_8021Q); // 0x8100 
+    testPkt->setEtherType(ETH_P_8021Q);  // 0x8100
     testPkt->setDstMac("33:22:0a:2e:ff:f1");
     testPkt->setEtherPayloadStr(
         "000b 0800 4500 0054 40b3 4000"
@@ -169,7 +169,7 @@ void TestPacketLibrary::buildTestPacketLibrary(void)
     //
     testPkt = &_testPacketLibrary[TEST_PKT_ID_MPLS_L2VLAN];
 
-    testPkt->setEtherType(ETH_P_MPLS_UC); // 0x8847 
+    testPkt->setEtherType(ETH_P_MPLS_UC);  // 0x8847
     testPkt->setDstMac("33:22:0a:2e:ff:f1");
     testPkt->setEtherPayloadStr(
         "000c 8847 000c 81ff 3322 0a2e fff1 5ed8 f932"
@@ -183,19 +183,19 @@ void TestPacketLibrary::buildTestPacketLibrary(void)
     //
     // TEST_PKT_ID_IPV4_ROUTER_ICMP_ECHO_TO_TAP7
     //
-	// Src IP : 103.30.60.2
-	// Dst IP : 103.30.70.3
+    // Src IP : 103.30.60.2
+    // Dst IP : 103.30.70.3
     testPkt = &_testPacketLibrary[TEST_PKT_ID_IPV4_ROUTER_ICMP_ECHO_TO_TAP7];
 
-    testPkt->setDstMac("32:26:0a:2e:aa:f6"); // ge-0/0/6 mac
-    testPkt->setSrcMac("32:26:0A:2e:bb:f6"); // vmx_link6 MAC
-    testPkt->setEtherType(ETH_P_IP);         // 0x0800 
+    testPkt->setDstMac("32:26:0a:2e:aa:f6");  // ge-0/0/6 mac
+    testPkt->setSrcMac("32:26:0A:2e:bb:f6");  // vmx_link6 MAC
+    testPkt->setEtherType(ETH_P_IP);          // 0x0800
     testPkt->setEtherPayloadStr(
-		"4500 0054 dacc 4000 4001 0f9c"
-		"671e 3c01 671e 4603"                // 103.30.60.2 -> 103.30.70.3
-		"0800 5cba 492b 3942 ee7c 5658 0000"
-		"0000 0a30 0b00 0000 0000 1011 1213 1415"
-		"1617 1819 1a1b 1c1d 1e1f 2021 2223 2425"
-		"2627 2829 2a2b 2c2d 2e2f 3031 3233 3435"
-		"3637");
+        "4500 0054 dacc 4000 4001 0f9c"
+        "671e 3c01 671e 4603"  // 103.30.60.2 -> 103.30.70.3
+        "0800 5cba 492b 3942 ee7c 5658 0000"
+        "0000 0a30 0b00 0000 0000 1011 1213 1415"
+        "1617 1819 1a1b 1c1d 1e1f 2021 2223 2425"
+        "2627 2829 2a2b 2c2d 2e2f 3031 3233 3435"
+        "3637");
 }

--- a/test/gtest/src/TestUtils.cpp
+++ b/test/gtest/src/TestUtils.cpp
@@ -18,56 +18,58 @@
 // components is subject to the terms and conditions of the respective license
 // as noted in the Third-Party source code file.
 //
+#include "TestUtils.h"
 
 #include <arpa/inet.h>
+#include <libnet.h>
 #include <linux/if_packet.h>
-#include <signal.h>
-#include <stdio.h>
-#include <string.h>
-#include <stdlib.h>
-#include <sys/wait.h>
-#include <unistd.h>
-#include <iostream>
-#include <memory>
-#include <thread>
-#include <boost/filesystem.hpp>
-#include <sys/ioctl.h>
-#include <sys/socket.h>
 #include <net/if.h>
 #include <netinet/ether.h>
 #include <pcap.h>
-#include <libnet.h>
-#include "gtest/gtest.h"
-#include "TestPacket.h"
+#include <signal.h>
+#include <sys/ioctl.h>
+#include <sys/socket.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include <boost/filesystem.hpp>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <iostream>
+#include <memory>
+#include <string>
+#include <thread>
+#include <vector>
+
 #include "P4InfoUtils.h"
-#include "TestUtils.h"
 #include "TapIf.h"
+#include "gtest/gtest.h"
 
-#define SEND_BUF_SIZE		    1500
-#define ETHER_PAYLOAD_BUF_SIZE	5000
+#define SEND_BUF_SIZE 1500
+#define ETHER_PAYLOAD_BUF_SIZE 5000
 
-#define SEND_BUF_STR_SIZE	    5000
-
+#define SEND_BUF_STR_SIZE 5000
 
 std::string gTestTimeStr;
 std::string gtestOutputDirName;
 std::string gtestExpectedDirName = "GTEST_EXPECTED";
-std::string tsharkBinary = "/usr/bin/tshark -o ip.check_checksum:TRUE";
+std::string tsharkBinary         = "/usr/bin/tshark -o ip.check_checksum:TRUE";
 
-static pcap_t *pcap_hdl; // Packet capture handle.
+static pcap_t *pcap_hdl;  // Packet capture handle.
 
 std::string
 getTimeStr()
 {
-    time_t rawtime;
-    struct tm *timeinfo;
-    char buffer[80];
+    time_t    rawtime;
+    struct tm timeinfo;
 
     time(&rawtime);
-    timeinfo = localtime(&rawtime);
+    localtime_r(&rawtime, &timeinfo);
 
-    strftime(buffer, 80, "%d%m%Y_%I%M%S", timeinfo);
-    return std::string{buffer};
+    char buffer[80];
+    strftime(buffer, 80, "%d%m%Y_%I%M%S", &timeinfo);
+    return std::string(buffer);
 }
 
 void
@@ -78,23 +80,24 @@ sleep_thread_log(std::chrono::milliseconds nms)
     std::cout << "Done." << std::endl;
 }
 
-std::string
-getShellCmdOutput(std::string &cmd)
+static std::string
+getShellCmdOutput(const std::string &cmd)
 {
     std::array<char, 128> buff;
-
-    std::string output;
+    std::string           output;
     std::shared_ptr<FILE> pipe(popen(cmd.c_str(), "r"), pclose);
     if (!pipe) throw std::runtime_error("popen() failed!");
     while (!feof(pipe.get())) {
-        if (fgets(buff.data(), 128, pipe.get()) != NULL)
+        if (fgets(buff.data(), 128, pipe.get()) != NULL) {
             output += buff.data();
+        }
     }
     return output;
 }
 
 // SIGALRM handler to timeout the pkt listen loop.
-static void alarm_handler(int sig)
+static void
+alarm_handler(int sig)
 {
     pcap_breakloop(pcap_hdl);
 }
@@ -105,13 +108,14 @@ static void alarm_handler(int sig)
  * process since it uses a signal handler for SIGALRM to break the packet
  * capture loop.
  */
-void listen_pkt_intf(const char *intf, const char *dump_file,
-                     unsigned int num_pkts, unsigned int to_sec)
+void
+listen_pkt_intf(const char *intf, const char *dump_file, unsigned int num_pkts,
+                unsigned int to_sec)
 {
-    int ret = 0;
-    int exit_status = EXIT_FAILURE;
-    char errbuf[PCAP_ERRBUF_SIZE];
-    pcap_dumper_t *pd = nullptr;
+    int              ret         = 0;
+    int              exit_status = EXIT_FAILURE;
+    char             errbuf[PCAP_ERRBUF_SIZE];
+    pcap_dumper_t *  pd = nullptr;
     struct sigaction psa;
 
     std::cout << "\nListening for packets on interface " << intf << std::endl;
@@ -131,7 +135,8 @@ void listen_pkt_intf(const char *intf, const char *dump_file,
     sigaction(SIGALRM, &psa, NULL);
     alarm(to_sec);
 
-    ret = pcap_loop(pcap_hdl, num_pkts, pcap_dump, (u_char *)pd);
+    ret = pcap_loop(pcap_hdl, num_pkts, pcap_dump,
+                    reinterpret_cast<u_char *>(pd));
     if (ret == -2) {
         std::cout << "Timed out listening for packets on intf " << intf
                   << std::endl;
@@ -154,15 +159,14 @@ quit:
  * interface.
  */
 void
-start_pktcap(const std::vector<std::string> &intfs,
-             unsigned int num_pkts, unsigned int timeout_sec,
-             std::vector<pid_t> &pids)
+start_pktcap(const std::vector<std::string> &intfs, unsigned int num_pkts,
+             unsigned int timeout_sec, std::vector<pid_t> &pids)
 {
     const ::testing::TestInfo *const test_info =
         ::testing::UnitTest::GetInstance()->current_test_info();
     const std::string tOutputDir = gtestOutputDirName + "/" +
-                                   std::string{test_info->test_case_name()} +
-                                   "/" + std::string{test_info->name()};
+                                   std::string(test_info->test_case_name()) +
+                                   "/" + std::string(test_info->name());
 
     ASSERT_TRUE(boost::filesystem::create_directories(tOutputDir));
 
@@ -170,7 +174,7 @@ start_pktcap(const std::vector<std::string> &intfs,
     pids.clear();
     for (const auto &intf : intfs) {
         ifPcapFile = tOutputDir + "/" + intf + ".pcap";
-        pid_t cid = fork();
+        pid_t cid  = fork();
         if (cid == -1) break;
         if (cid > 0) {
             pids.push_back(cid);
@@ -191,7 +195,7 @@ start_pktcap(const std::vector<std::string> &intfs,
 // Wait for pcap child processes and verify exit status.
 bool
 stop_pktcap(const std::vector<std::string> &intfs,
-            const std::vector<pid_t> &pids)
+            const std::vector<pid_t> &      pids)
 {
     bool pcap_status = true;
 
@@ -211,16 +215,16 @@ stop_pktcap(const std::vector<std::string> &intfs,
 void
 tVerifyPackets(const std::vector<std::string> &interfaces)
 {
-    int ret = 0;
-    std::string cmd;
+    int                              ret = 0;
+    std::string                      cmd;
     const ::testing::TestInfo *const test_info =
         ::testing::UnitTest::GetInstance()->current_test_info();
-    const std::string tDir = std::string{test_info->test_case_name()} + "/" +
-                             std::string{test_info->name()};
-    const std::string tOutputDir = gtestOutputDirName + "/" + tDir;
+    const std::string tDir = std::string(test_info->test_case_name()) + "/" +
+                             std::string(test_info->name());
+    const std::string tOutputDir   = gtestOutputDirName + "/" + tDir;
     const std::string tExpectedDir = gtestExpectedDirName + "/" + tDir;
 
-    for(auto interface : interfaces) {
+    for (auto interface : interfaces) {
         std::string ifPcapFile = tOutputDir + "/" + interface + ".pcap";
         std::string ifPktsFile = tOutputDir + "/" + interface + ".pkts";
         std::string ifExpectedPcapFile =
@@ -228,11 +232,11 @@ tVerifyPackets(const std::vector<std::string> &interfaces)
         std::string ifExpectedPktsFile =
             tOutputDir + "/" + interface + ".pkts.expected";
 
-        cmd = tsharkBinary + " -nx " + " -r " + ifExpectedPcapFile + " > " + 
+        cmd = tsharkBinary + " -nx " + " -r " + ifExpectedPcapFile + " > " +
               ifExpectedPktsFile + " 2> /dev/null";
         ret = system(cmd.c_str());
         EXPECT_EQ(0, ret);
-        cmd = tsharkBinary + " -nx " + " -r " + ifPcapFile + " > " + 
+        cmd = tsharkBinary + " -nx " + " -r " + ifPcapFile + " > " +
               ifPktsFile + " 2> /dev/null";
         ret = system(cmd.c_str());
         EXPECT_EQ(0, ret);
@@ -254,10 +258,10 @@ tVerifyPackets(const std::vector<std::string> &interfaces)
                   " 2> /dev/null";
             std::cout << getShellCmdOutput(cmd);
             std::cout << "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~" << std::endl;
-            std::cout << "Actual: "<< ifPcapFile << std::endl;
+            std::cout << "Actual: " << ifPcapFile << std::endl;
             std::cout << "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~" << std::endl;
-            cmd = tsharkBinary + " -nVx " + " -r " + ifPcapFile +
-                  " 2> /dev/null";
+            cmd =
+                tsharkBinary + " -nVx " + " -r " + ifPcapFile + " 2> /dev/null";
             std::cout << getShellCmdOutput(cmd);
         } else {
             // No diff
@@ -268,136 +272,139 @@ tVerifyPackets(const std::vector<std::string> &interfaces)
 }
 
 int
-SendRawEth (const std::string &ifNameStr,
-            TestPacketLibrary::TestPacketId tcPktNum)
+SendRawEth(const std::string &             ifNameStr,
+           TestPacketLibrary::TestPacketId tcPktNum)
 {
-    int         i;
-	int         ether_type;
-	char       *ether_payload = NULL;
-	int        *dst_mac;
+    int   i;
+    int   ether_type;
+    char *ether_payload = NULL;
+    int * dst_mac;
 
-	int         sockfd;
-	struct      ifreq if_idx;
-	struct      ifreq if_mac;
-	int         tx_len = 0;
-	char        sendbuf[SEND_BUF_SIZE];
-	struct      ether_header *eh = (struct ether_header *) sendbuf;
-	struct      sockaddr_ll socket_address;
-	char        ifName[IFNAMSIZ];
-	int         byte_count;
+    int                  sockfd;
+    struct ifreq         if_idx;
+    struct ifreq         if_mac;
+    int                  tx_len = 0;
+    char                 sendbuf[SEND_BUF_SIZE];
+    struct ether_header *eh = (struct ether_header *)sendbuf;
+    struct sockaddr_ll   socket_address;
+    char                 ifName[IFNAMSIZ];
+    int                  byte_count;
 
-    TestPacket* testPkt = testPacketLibrary.getTestPacket(tcPktNum);
+    TestPacket *testPkt = testPacketLibrary.getTestPacket(tcPktNum);
 
-	ether_type    = testPkt->getEtherType();
-	dst_mac       = testPkt->getDstMac();
-	ether_payload = testPkt->getEtherPayloadStr();
+    ether_type    = testPkt->getEtherType();
+    dst_mac       = testPkt->getDstMac();
+    ether_payload = testPkt->getEtherPayloadStr();
 
     strncpy(ifName, ifNameStr.c_str(), IFNAMSIZ);
-	ifName[IFNAMSIZ - 1] = '\0';
+    ifName[IFNAMSIZ - 1] = '\0';
 
-	// RAW socket
-	if ((sockfd = socket(AF_PACKET, SOCK_RAW, IPPROTO_RAW)) == -1) {
-	    perror("socket");
-	}
+    // RAW socket
+    if ((sockfd = socket(AF_PACKET, SOCK_RAW, IPPROTO_RAW)) == -1) {
+        perror("socket");
+    }
 
-	// Get interface index */
-	memset(&if_idx, 0, sizeof(struct ifreq));
-	strncpy(if_idx.ifr_name, ifName, IFNAMSIZ-1);
+    // Get interface index */
+    memset(&if_idx, 0, sizeof(struct ifreq));
+    strncpy(if_idx.ifr_name, ifName, IFNAMSIZ - 1);
 
-	if (ioctl(sockfd, SIOCGIFINDEX, &if_idx) < 0) {
-	    perror("SIOCGIFINDEX");
-	}
+    if (ioctl(sockfd, SIOCGIFINDEX, &if_idx) < 0) {
+        perror("SIOCGIFINDEX");
+    }
 
-	// Get the MAC address of the interface to send on 
-	memset(&if_mac, 0, sizeof(struct ifreq));
-	strncpy(if_mac.ifr_name, ifName, IFNAMSIZ-1);
-	if (ioctl(sockfd, SIOCGIFHWADDR, &if_mac) < 0) {
-	    perror("SIOCGIFHWADDR");
+    // Get the MAC address of the interface to send on
+    memset(&if_mac, 0, sizeof(struct ifreq));
+    strncpy(if_mac.ifr_name, ifName, IFNAMSIZ - 1);
+    if (ioctl(sockfd, SIOCGIFHWADDR, &if_mac) < 0) {
+        perror("SIOCGIFHWADDR");
     }
 
     //
-	// Build Ethernet header
-	//
-	memset(sendbuf, 0, SEND_BUF_SIZE);
+    // Build Ethernet header
+    //
+    memset(sendbuf, 0, SEND_BUF_SIZE);
 
-	// Destination MAC
-	for (i = 0; i < MAC_ADDR_LEN; i++) {
-		eh->ether_dhost[i] = dst_mac[i];
-	}
+    // Destination MAC
+    for (i = 0; i < MAC_ADDR_LEN; i++) {
+        eh->ether_dhost[i] = dst_mac[i];
+    }
 
-	// Source MAC
-	for (i = 0; i < MAC_ADDR_LEN; i++) {
-		eh->ether_shost[i] = ((uint8_t *)&if_mac.ifr_hwaddr.sa_data)[i];
-	}
+    // Source MAC
+    for (i = 0; i < MAC_ADDR_LEN; i++) {
+        eh->ether_shost[i] =
+            (reinterpret_cast<uint8_t *>(&if_mac.ifr_hwaddr.sa_data))[i];
+    }
 
-	// Ethertype field
-	eh->ether_type = htons(ether_type);
-	tx_len        += sizeof(struct ether_header);
+    // Ethertype field
+    eh->ether_type = htons(ether_type);
+    tx_len += sizeof(struct ether_header);
 
-	getRidOfSpacesFromString(ether_payload);
+    getRidOfSpacesFromString(ether_payload);
 
-	byte_count = convertHexStringToBinary(ether_payload, 
-                                          &sendbuf[tx_len], 
+    byte_count = convertHexStringToBinary(ether_payload, &sendbuf[tx_len],
                                           (SEND_BUF_SIZE - tx_len));
 
-	tx_len += byte_count;
+    tx_len += byte_count;
 
-	// Index of the network device
-	socket_address.sll_ifindex = if_idx.ifr_ifindex;
-	// Address length
-	socket_address.sll_halen = ETH_ALEN;
+    // Index of the network device
+    socket_address.sll_ifindex = if_idx.ifr_ifindex;
+    // Address length
+    socket_address.sll_halen = ETH_ALEN;
 
-	// Destination MAC 
-	for (i = 0; i < MAC_ADDR_LEN; i++) {
-		socket_address.sll_addr[i] = dst_mac[i];
-	}
+    // Destination MAC
+    for (i = 0; i < MAC_ADDR_LEN; i++) {
+        socket_address.sll_addr[i] = dst_mac[i];
+    }
 
-	std::cout << "Sending packet on interface " << ifName << "..." << std::endl;
+    std::cout << "Sending packet on interface " << ifName << "..." << std::endl;
     pktTrace("Raw socket send", sendbuf, tx_len);
 
-	// Send packet 
-	if (sendto(sockfd, sendbuf, tx_len, 0, 
-	    (struct sockaddr*)&socket_address, sizeof(struct sockaddr_ll)) < 0) {
-	    std::cout << "Error: Send failed!" << std::endl;
-		return -1;
-	} else {
-	    std::cout << "Send success!!!" << std::endl;
-		return 0;
-	}
+    // Send packet
+    if (sendto(sockfd, sendbuf, tx_len, 0, (struct sockaddr *)&socket_address,
+               sizeof(struct sockaddr_ll)) < 0) {
+        std::cout << "Error: Send failed!" << std::endl;
+        return -1;
+    } else {
+        std::cout << "Send success!!!" << std::endl;
+        return 0;
+    }
 }
 
 void
 send_arp_req(const std::string &ifname, const char *target_ip_addr)
 {
-    char errbuf[LIBNET_ERRBUF_SIZE]{};
+    char      errbuf[LIBNET_ERRBUF_SIZE]{};
     libnet_t *l = libnet_init(LIBNET_LINK, ifname.c_str(), errbuf);
     ASSERT_NE(nullptr, l) << "libnet_init() failed: " << errbuf;
 
     std::unique_ptr<libnet_t, decltype(&libnet_destroy)> lup{l, libnet_destroy};
 
-    uint32_t src_ip_addr = libnet_get_ipaddr4(l);
-    ASSERT_NE(-1, src_ip_addr)
+    uint32_t sip = libnet_get_ipaddr4(l);
+    ASSERT_NE((uint32_t)-1, sip)
         << "Couldn't get own IP addr: " << libnet_geterror(l);
 
     struct libnet_ether_addr *src_mac_addr = libnet_get_hwaddr(l);
     ASSERT_NE(nullptr, src_mac_addr)
         << "Couldn't get own MAC addr: " << libnet_geterror(l);
 
-    std::string tip_str{target_ip_addr};
-    uint32_t tip = libnet_name2addr4(l, &tip_str[0], LIBNET_DONT_RESOLVE);
-    ASSERT_NE(-1, tip) << "Error converting IP addr: " << libnet_geterror(l);
+    std::string tip_str(target_ip_addr);
+    uint32_t    tip = libnet_name2addr4(l, &tip_str[0], LIBNET_DONT_RESOLVE);
+    ASSERT_NE((uint32_t)-1, tip)
+        << "Error converting IP addr: " << libnet_geterror(l);
 
-    uint8_t mac_zero_addr[6]{};
-    libnet_ptag_t pt = libnet_autobuild_arp(
-        ARPOP_REQUEST, src_mac_addr->ether_addr_octet, (uint8_t *)&src_ip_addr,
-        mac_zero_addr, (uint8_t *)&tip, l);
+    uint8_t       mac_zero_addr[6]{};
+    auto *        sip_bytes = reinterpret_cast<uint8_t *>(&sip);
+    auto *        tip_bytes = reinterpret_cast<uint8_t *>(&tip);
+    libnet_ptag_t pt =
+        libnet_autobuild_arp(ARPOP_REQUEST, src_mac_addr->ether_addr_octet,
+                             sip_bytes, mac_zero_addr, tip_bytes, l);
     ASSERT_NE(-1, pt) << "Error building ARP header: " << libnet_geterror(l);
 
     uint8_t mac_bcast_addr[6] = {0xff, 0xff, 0xff, 0xff, 0xff, 0xff};
     pt = libnet_autobuild_ethernet(mac_bcast_addr, ETHERTYPE_ARP, l);
     ASSERT_NE(-1, pt) << "Error building ethernet hdr" << libnet_geterror(l);
 
-    int bytes_written = libnet_write(l);
+    const int bytes_written = libnet_write(l);
     ASSERT_NE(-1, bytes_written)
         << "Error writing packet: " << libnet_geterror(l);
 

--- a/tools/docker/Dockerfile_p4
+++ b/tools/docker/Dockerfile_p4
@@ -63,6 +63,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
  libtool \
  libxml2-utils \
  libyaml-cpp-dev \
+ nano \
  net-tools \
  nmap \
  openssh-client \
@@ -87,8 +88,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 # Clang related packages
 RUN wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
-RUN apt-add-repository -y "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-5.0 main"
-RUN apt-get update && apt-get install -y --no-install-recommends clang-5.0 clang-format-5.0 clang-tidy-5.0
+RUN apt-add-repository -y "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-6.0 main"
+RUN apt-get update && apt-get install -y --no-install-recommends clang-6.0 clang-format-6.0 clang-tidy-6.0
+RUN update-alternatives --install /usr/bin/clang clang /usr/bin/clang-6.0 10
+RUN update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-6.0 10
+RUN update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-6.0 10
+RUN update-alternatives --install /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-6.0 10
 
 #
 # Packages needed for p4c


### PR DESCRIPTION
* Use GTest provided classes to setup things common to all tests.
* Fix cpplint issues.
* Apply proper-formatting with clang-format.